### PR TITLE
Fix warning when including SVProgressHUD as an embedded Framework:

### DIFF
--- a/SVProgressHUD-Framework.h
+++ b/SVProgressHUD-Framework.h
@@ -1,0 +1,15 @@
+//
+//  SVProgressHUD-Framework.h
+//  SVProgressHUD
+//
+//  Created by Chris Rittersdorf on 12/4/15.
+//  Copyright © 2015 EmbeddedSources. All rights reserved.
+//
+
+
+// This is an empty header file to quiet warnings for
+#ifndef SVProgressHUD_Framework_h
+#define SVProgressHUD_Framework_h
+
+
+#endif /* SVProgressHUD_Framework_h */

--- a/SVProgressHUD.xcodeproj/project.pbxproj
+++ b/SVProgressHUD.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		65F0220015C857EF0030BBEF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65F021FF15C857EF0030BBEF /* Foundation.framework */; };
 		65F0220515C857EF0030BBEF /* SVProgressHUD.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 65F0220415C857EF0030BBEF /* SVProgressHUD.h */; };
 		65F0220715C857EF0030BBEF /* SVProgressHUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 65F0220615C857EF0030BBEF /* SVProgressHUD.m */; };
+		A7E0963C1C11F8E10038220B /* SVProgressHUD-Framework.h in Headers */ = {isa = PBXBuildFile; fileRef = A7E0963B1C11F8E10038220B /* SVProgressHUD-Framework.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -47,6 +48,7 @@
 		65F0220415C857EF0030BBEF /* SVProgressHUD.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVProgressHUD.h; sourceTree = "<group>"; };
 		65F0220615C857EF0030BBEF /* SVProgressHUD.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SVProgressHUD.m; sourceTree = "<group>"; };
 		65F0220D15C858060030BBEF /* SVProgressHUD.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = SVProgressHUD.bundle; sourceTree = "<group>"; };
+		A7E0963B1C11F8E10038220B /* SVProgressHUD-Framework.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SVProgressHUD-Framework.h"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,6 +73,7 @@
 		4A9D7DD91AB345990039B273 /* SVProgressHUD-Framework */ = {
 			isa = PBXGroup;
 			children = (
+				A7E0963B1C11F8E10038220B /* SVProgressHUD-Framework.h */,
 				4A9D7DDA1AB345990039B273 /* Supporting Files */,
 			);
 			path = "SVProgressHUD-Framework";
@@ -142,6 +145,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4A9D7DF31AB345E10039B273 /* SVProgressHUD.h in Headers */,
+				A7E0963C1C11F8E10038220B /* SVProgressHUD-Framework.h in Headers */,
 				4A9D7DF41AB345E80039B273 /* SVIndefiniteAnimatedView.h in Headers */,
 				3CB14F9C1AFBCB57003C2641 /* SVRadialGradientLayer.h in Headers */,
 			);

--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -7,7 +7,7 @@
 
 #import <UIKit/UIKit.h>
 #import <AvailabilityMacros.h>
-
+#import "SVProgressHUD-Framework.h"
 #if __IPHONE_OS_VERSION_MAX_ALLOWED < 70000
 
 #define UI_APPEARANCE_SELECTOR


### PR DESCRIPTION
When installing SVProgressHUD with Carthage, I received the following warning:

```
<module-includes>:1:1: Umbrella header for module 'SVProgressHUD' does not include header 'SVProgressHUD-Framework.h'
```

By including an empty header, this should quiet the warning.
